### PR TITLE
Add windows support via msys2 / mingw (ucrt64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
             base-devel 
             mingw-w64-ucrt-x86_64-toolchain
             mingw-w64-ucrt-x86_64-meson
-            mingw-w64-ucrt-x86_64-clang
             mingw-w64-ucrt-x86_64-fftw
             mingw-w64-ucrt-x86_64-libsndfile
             mingw-w64-ucrt-x86_64-pkgconf
@@ -31,7 +30,7 @@ jobs:
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'
-          meson setup -native-file clang.ini build
+          meson setup build
           meson compile -C build
       - name: Save Build Log Artifact
         if: ${{ always() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,33 +39,33 @@ jobs:
         with:
           name: meson-build-log-${{ runner.os }}.txt
           path: build/meson-logs/meson-log.tx
-  # build:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-latest, ubuntu-latest]
-  #   runs-on: ${{ matrix.os }}
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
-  #   steps:
-  #   - uses: actions/checkout@v4
+    steps:
+    - uses: actions/checkout@v4
 
-  #   - name: Install Linux Dependencies
-  #     if: runner.os == 'Linux'
-  #     run: .github/scripts/install-debian-deps.sh
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: .github/scripts/install-debian-deps.sh
 
-  #   - name: Install macOS Dependencies
-  #     if: runner.os == 'macOS'
-  #     run: .github/scripts/install-macos-deps.sh
+    - name: Install macOS Dependencies
+      if: runner.os == 'macOS'
+      run: .github/scripts/install-macos-deps.sh
 
-  #   - name: Setup
-  #     run: meson setup build
+    - name: Setup
+      run: meson setup build
 
-  #   - name: Compile
-  #     run: meson compile -C build
+    - name: Compile
+      run: meson compile -C build
 
-  #   - name: Save Build Log Artifact
-  #     if: ${{ always() }}
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: meson-build-log-${{ runner.os }}.txt
-  #       path: build/meson-logs/meson-log.txt
+    - name: Save Build Log Artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: meson-build-log-${{ runner.os }}.txt
+        path: build/meson-logs/meson-log.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,33 +7,65 @@ on:
     branches: [ "main" ]
     
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-
+  msys2-ucrt64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            base-devel 
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-meson
+            mingw-w64-ucrt-x86_64-clang
+            mingw-w64-ucrt-x86_64-fftw
+            mingw-w64-ucrt-x86_64-libsndfile
+            mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-rtaudio
+            mingw-w64-ucrt-x86_64-readline
+      - name: CI-Build
+        run: |
+          echo 'Running in MSYS2!'
+          meson setup -native-file clang.ini build
+          meson compile -C build
+      - name: Save Build Log Artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: meson-build-log-${{ runner.os }}.txt
+          path: build/meson-logs/meson-log.tx
+  # build:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-latest, ubuntu-latest]
+  #   runs-on: ${{ matrix.os }}
 
-    - name: Install Linux Dependencies
-      if: runner.os == 'Linux'
-      run: .github/scripts/install-debian-deps.sh
+  #   steps:
+  #   - uses: actions/checkout@v4
 
-    - name: Install macOS Dependencies
-      if: runner.os == 'macOS'
-      run: .github/scripts/install-macos-deps.sh
+  #   - name: Install Linux Dependencies
+  #     if: runner.os == 'Linux'
+  #     run: .github/scripts/install-debian-deps.sh
 
-    - name: Setup
-      run: meson setup build
+  #   - name: Install macOS Dependencies
+  #     if: runner.os == 'macOS'
+  #     run: .github/scripts/install-macos-deps.sh
 
-    - name: Compile
-      run: meson compile -C build
+  #   - name: Setup
+  #     run: meson setup build
 
-    - name: Save Build Log Artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: meson-build-log-${{ runner.os }}.txt
-        path: build/meson-logs/meson-log.txt
+  #   - name: Compile
+  #     run: meson compile -C build
+
+  #   - name: Save Build Log Artifact
+  #     if: ${{ always() }}
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: meson-build-log-${{ runner.os }}.txt
+  #       path: build/meson-logs/meson-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ xcshareddata/
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+.vscode/
+build.txt

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ xcshareddata/
 *.moved-aside
 *.xcuserstate
 .vscode/
-build.txt
-sapf-examples-windows.txt

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 - [install-debian-deps.sh](.github/scripts/install-debian-deps.sh) (Debian, Ubuntu, Mint, etc.)
 - [install-macos-deps.sh](.github/scripts/install-macos-deps.sh) (macOS with Homebrew)
 
-## Windows
+## Windows Usage Caveats
+
+Windows support is currently WIP. The following current limitations apply:
+
+- In order to paste multiline contents, you should make sure the line ending is LF only (not Windows-style CRLF). CRLF pasting isn't working right currently.
+- It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
+    all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
+
+## Windows Build + Development
 
 (I'm new to this toolchain so some things may be wrong)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Windows support is currently WIP. The following current "quirks" apply:
 
 - It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
     all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
+- History loading from previous sessions isn't working.
 - When pasting in multiline strings, they should work. Just note that many built-in Windows terminals by default will strip out certain characters like tabs,
     ruining your beautiful formatting. This can be changed in the terminal's settings.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 Windows support is currently WIP. The following current "quirks" apply:
 
-- It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
-    all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
+- It will default to WASAPI and use your primary output device. Ability to select different devices or audio drivers (ASIO, etc..) is not yet supported.
 - When pasting in multiline strings, they should work. Just note that many built-in Windows terminals by default will strip out certain characters like tabs,
     ruining your beautiful formatting. This can be changed in the terminal's settings.
 
@@ -80,11 +79,8 @@ Navigate to the root directory of this repo.
 and copy all of the dlls that look like `lib*.dll` (i.e. libreadline8.dll, libogg-0.dll, etc...). This is
 more than needed but I'm not sure the exact subset of dlls needed yet.
 1. Now you can run the exe directly by clicking or via your preferred command prompt.
-1. Test if its all working with a simple command (you should hear audio)
+1. Test if its all working with a simple command (you should hear audio out of your primary output device)
 `15 .0 sinosc 200 * 300 + .0 sinosc .1 * play`
-1. If you didn't hear anything check if ASIO4ALL launched (in the taskbar icons) and
-open it up and enable your preferred output device. Then restart sapf. 
-    - We plan to eventually make it possible to select an audio device, which is kind of necessary for Windows but not so much for other systems.
 
 ### Windows VSCode Development Setup
 Since it's not exactly straightforward to get everything working nicely in VSCode under Windows, here's 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 ## Windows Usage Caveats
 
-Windows support is currently WIP. The following current limitations apply:
+Windows support is currently WIP. The following current "quirks" apply:
 
 - It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
     all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
+- When pasting in multiline strings, they should work. Just note that many built-in Windows terminals by default will strip out certain characters like tabs,
+    ruining your beautiful formatting. This can be changed in the terminal's settings.
 
 ## Windows Build + Development
 

--- a/README.md
+++ b/README.md
@@ -38,185 +38,48 @@ Windows support is currently WIP. The following current "quirks" apply:
 
 ## Windows Build + Development
 
-(I'm new to this toolchain so some things may be wrong)
-
 Windows support is achieved by building via [msys2](https://www.msys2.org/) (using mingw-w64-ucrt6) as opposed to building natively on Windows (probably possible but probably much more annoying).
-
-I believe the project specifically requires clang.
 
 If you're for some reason not on x86_64, you'll have to replace any of the below references to that architecture
 with your own! You can find and view info on packages on [msys2 packages](https://packages.msys2.org/queue) to see
-if the package exists for your architecture. Note these packages often also have "-clang" versions, but AFAICT we
-DON'T want to install those as they end up in a location that isn't found by default for this toolchain.
+if the package exists for your architecture. 
 
 1. Install [msys2](https://www.msys2.org/). Make sure to keep track of where you installed it as this will be where your
 "root directory" is for your msys2 / mingw64 shells. For this guide we will assume the default of `C:\msys64`
-1. If you haven't yet, clone or copy this repo somewhere inside the msys2 install. For example within the msys2 shell you could install git via
+2. If you haven't yet, clone or copy this repo somewhere inside the msys2 install. For example within the msys2 shell you could install git via
 `pacman -S git` and then git clone this repo into your "home" folder.
-1. Open a msys2 (ucrt) shell and install some needed development dependencies
+3. Open a msys2 (ucrt) shell and install some needed development dependencies
    ```shell
    # press ENTER when prompted to choose "all"
    pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
    pacman -S \
     mingw-w64-ucrt-x86_64-meson \
-    mingw-w64-ucrt-x86_64-clang \
     mingw-w64-ucrt-x86_64-fftw \
     mingw-w64-ucrt-x86_64-libsndfile \
     mingw-w64-ucrt-x86_64-pkgconf \
     mingw-w64-ucrt-x86_64-rtaudio \
     mingw-w64-ucrt-x86_64-readline
    ```
-1. Close and reopen the shell to ensure it loads everything you just installed. 
-1. Now we can try to build in the msys2 (ucrt) shell. We need to always pass our `--native-file` which forces meson to use clang.
+4. Close and reopen the shell to ensure it loads everything you just installed. 
+5. Now we can try to build in the msys2 (ucrt) shell.
 Navigate to the root directory of this repo.
-1.  ```shell
-    # remove --buildtype debug to build without debug symbols (I think?)
-    meson setup --buildtype debug --native-file clang.ini build 
+6.  ```shell
+    # remove --buildtype debug to build without debug symbols
+    meson setup --buildtype debug build 
     meson compile -C build
     ```
-1. You should see `sapf.exe` is created under the `${workspaceFolder}/build` directory.
-1. You need all the required DLLs in order to run it via Windows. Go to your msys2 folder `C:\msys64\ucrt64\bin`
+7. You should see `sapf.exe` is created under the `${workspaceFolder}/build` directory.
+8. You need all the required DLLs in order to run it via Windows. Go to your msys2 folder `C:\msys64\ucrt64\bin`
 and copy all of the dlls that look like `lib*.dll` (i.e. libreadline8.dll, libogg-0.dll, etc...). This is
 more than needed but I'm not sure the exact subset of dlls needed yet.
-1. Now you can run the exe directly by clicking or via your preferred command prompt.
-1. Test if its all working with a simple command (you should hear audio out of your primary output device)
+9. Now you can run the exe directly by clicking or via your preferred command prompt.
+10. Test if its all working with a simple command (you should hear audio out of your primary output device)
 `15 .0 sinosc 200 * 300 + .0 sinosc .1 * play`
 
-### Windows VSCode Development Setup
+When setting up your IDE, make sure it's using the ucrt64 libraries (C:\msys64\ucrt64\include)
+and binaries (C:\msys64\ucrt64\bin) for compilation / linking and NOT your native windows libraries / binaries.
+
+See README_VSCODE.md for vscode-specific setup.
 Since it's not exactly straightforward to get everything working nicely in VSCode under Windows, here's 
 some guidance.
 
-The trick to making it work is to make sure VSCode is using the ucrt64 binaries for the development toolchain,
-NOT anything installed natively to Windows.
-
-1. Install C/C++ extensions for VSCode.
-1. Install Meson extension for VSCode.
-1. In the settings for Meson, set Meson build path to `C:\msys64\ucrt64\bin\meson` and
-set the Build folder to `build`.
-1. Add your `C:\msys64\ucrt\bin` folder to your Path (via Environment Variables).
-1. Open a windows terminal and make sure that `gcc --version` and `g++ --version` and `gdb --version` return
-a version string. You can also confirm with `where gcc` that it's using the binary within msys2.
-1. Before opening the folder in vscode, create a `.vscode` subdolder and populate it with some files. See the below "Config files" section for some example config files. Tweak the paths to match your own system.
-1. Open a cpp file to make sure the extensions activate.
-1. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
-1. You can now build using the Meson build task instead of msys2 shell if you prefer.
-1. You can debug via selecting the "Attach (sapf)" configuration (bottom left), manually
-running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
-how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
-    - If it times out waiting to attach, try restarting VSCode and maybe also
-    closing any msys2 shells if you have any open (not sure what's going on here)?
-
-
-
-#### Config files
-Example `.vscode/c_cpp_properties.json`
-```json
-{
-    "configurations": [
-        {
-            "name": "ucrt64",
-            "includePath": [
-                "C:/msys64/ucrt64/include/**",
-                "${workspaceFolder}/**"
-            ],
-            "defines": [
-                "_DEBUG",
-                "UNICODE",
-                "_UNICODE"
-            ],
-            "compilerPath": "C:/msys64/ucrt64/bin/clang++.exe",
-            "windowsSdkVersion": "10.0.22621.0",
-            "cStandard": "c17",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "windows-clang-x64",
-            "configurationProvider": "mesonbuild.mesonbuild"
-        }
-    ],
-    "version": 4
-}
-```
-
-Example `.vscode/launch.json`
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "(gdb) Attach",
-            "type": "cppdbg",
-            "request": "attach",
-            "program": "${workspaceRoot}/build/sapf.exe",
-            "MIMode": "gdb",
-            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
-            ]
-        },
-        {
-            "name": "(gdb) Launch (chairbender note - not working ATM, use attach instead - everything is garbled)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceRoot}/build/sapf.exe",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceRoot}/build",
-            "environment": [
-                { "name": "MSYSTEM", "value": "UCRT64" },
-                { "name": "MSYS2_PATH_TYPE", "value": "inherit" },
-                { "name": "PATH", "value": "C:\\msys64\\ucrt64\\bin;${env:PATH}" }
-            ],
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
-            ]
-        }
-    ]
-}
-```
-
-Example `.vscode/settings.json`
-```json
-{
-    "C_Cpp.default.compileCommands": "c:\\msys64\\home\\kwhip\\sapf\\build/compile_commands.json",
-    "C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild"
-}
-```
-
-Example `.vscode/tasks.json`
-```json
-{
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "meson",
-			"target": "sapf:executable",
-			"mode": "build",
-			"problemMatcher": [
-				"$meson-gcc"
-			],
-			"group": "build",
-			"label": "Meson: Build sapf:executable"
-		}
-	]
-}
-```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,196 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 - [install-debian-deps.sh](.github/scripts/install-debian-deps.sh) (Debian, Ubuntu, Mint, etc.)
 - [install-macos-deps.sh](.github/scripts/install-macos-deps.sh) (macOS with Homebrew)
+
+## Windows
+
+(I'm new to this toolchain so some things may be wrong)
+
+Windows support is achieved by building via [msys2](https://www.msys2.org/) (using mingw-w64-ucrt6) as opposed to building natively on Windows (probably possible but probably much more annoying).
+
+I believe the project specifically requires clang.
+
+If you're for some reason not on x86_64, you'll have to replace any of the below references to that architecture
+with your own! You can find and view info on packages on [msys2 packages](https://packages.msys2.org/queue) to see
+if the package exists for your architecture. Note these packages often also have "-clang" versions, but AFAICT we
+DON'T want to install those as they end up in a location that isn't found by default for this toolchain.
+
+1. Install [msys2](https://www.msys2.org/). Make sure to keep track of where you installed it as this will be where your
+"root directory" is for your msys2 / mingw64 shells. For this guide we will assume the default of `C:\msys64`
+1. If you haven't yet, clone or copy this repo somewhere inside the msys2 install. For example within the msys2 shell you could install git via
+`pacman -S git` and then git clone this repo into your "home" folder.
+1. Open a msys2 (ucrt) shell and install some needed development dependencies
+   ```shell
+   # press ENTER when prompted to choose "all"
+   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+   pacman -S \
+    mingw-w64-ucrt-x86_64-meson \
+    mingw-w64-ucrt-x86_64-clang \
+    mingw-w64-ucrt-x86_64-fftw \
+    mingw-w64-ucrt-x86_64-libsndfile \
+    mingw-w64-ucrt-x86_64-pkgconf \
+    mingw-w64-ucrt-x86_64-rtaudio \
+    mingw-w64-ucrt-x86_64-readline
+   ```
+1. Close and reopen the shell to ensure it loads everything you just installed. 
+1. Now we can try to build in the msys2 (ucrt) shell. We need to always pass our `--native-file` which forces meson to use clang.
+Navigate to the root directory of this repo.
+1.  ```shell
+    # remove --buildtype debug to build without debug symbols (I think?)
+    meson setup --buildtype debug --native-file clang.ini build 
+    meson compile -C build
+    ```
+1. You should see `sapf.exe` is created under the `${workspaceFolder}/build` directory.
+1. You need all the required DLLs in order to run it via Windows. Go to your msys2 folder `C:\msys64\ucrt64\bin`
+and copy all of the dlls that look like `lib*.dll` (i.e. libreadline8.dll, libogg-0.dll, etc...). This is
+more than needed but I'm not sure the exact subset of dlls needed yet.
+1. Now you can run the exe directly by clicking or via your preferred command prompt.
+1. Test if its all working with a simple command (you should hear audio)
+`15 .0 sinosc 200 * 300 + .0 sinosc .1 * play`
+1. If you didn't hear anything check if ASIO4ALL launched (in the taskbar icons) and
+open it up and enable your preferred output device. Then restart sapf. 
+    - We want to make it possible to select an audio device, which is kind of necessary for Windows but not so much for other systems.
+
+### Windows VSCode Development Setup
+Since it's not exactly straightforward to get everything working nicely in VSCode under Windows, here's 
+some guidance.
+
+The trick to making it work is to make sure VSCode is using the ucrt64 binaries for the development toolchain,
+NOT anything installed natively to Windows.
+
+1. Install C/C++ extensions for VSCode.
+1. Install Meson extension for VSCode.
+1. In the settings for Meson, set Meson build path to `C:\msys64\ucrt64\bin\meson` and
+set the Build folder to `build`.
+1. Add your `C:\msys64\ucrt\bin` folder to your Path (via Environment Variables).
+1. Open a windows terminal and make sure that `gcc --version` and `g++ --version` and `gdb --version` return
+a version string. You can also confirm with `where gcc` that it's using the binary within msys2.
+1. Before opening the folder in vscode, create a `.vscode` subdolder and populate it with some files. See the below "Config files" section for some example config files. Tweak the paths to match your own system.
+1. Open a cpp file to make sure the extensions activate.
+1. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
+1. You can now build using the Meson build task instead of msys2 shell if you prefer.
+1. You can debug by opening up main.cpp and selecting the "Attach (sapf)" configuration (bottom left), manually
+running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
+how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
+    - IDK why but it seems like you have to actually have main.cpp open in order for it to succeed in attaching.
+
+
+
+#### Config files
+Example `.vscode/c_cpp_properties.json`
+```json
+{
+    "configurations": [
+        {
+            "name": "ucrt64",
+            "includePath": [
+                "C:/msys64/ucrt64/include/**",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compilerPath": "C:/msys64/ucrt64/bin/clang++.exe",
+            "windowsSdkVersion": "10.0.22621.0",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-clang-x64",
+            "configurationProvider": "mesonbuild.mesonbuild"
+        }
+    ],
+    "version": 4
+}
+```
+
+Example `.vscode/launch.json`
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceRoot}/build/sapf.exe",
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Launch (chairbender note - not working ATM, use attach instead - everything is garbled)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/sapf.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/build",
+            "environment": [
+                { "name": "MSYSTEM", "value": "UCRT64" },
+                { "name": "MSYS2_PATH_TYPE", "value": "inherit" },
+                { "name": "PATH", "value": "C:\\msys64\\ucrt64\\bin;${env:PATH}" }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}
+```
+
+Example `.vscode/settings.json`
+```json
+{
+    "C_Cpp.default.compileCommands": "c:\\msys64\\home\\kwhip\\sapf\\build/compile_commands.json",
+    "C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild"
+}
+```
+
+Example `.vscode/tasks.json`
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "meson",
+			"target": "sapf:executable",
+			"mode": "build",
+			"problemMatcher": [
+				"$meson-gcc"
+			],
+			"group": "build",
+			"label": "Meson: Build sapf:executable"
+		}
+	]
+}
+```
+
+### Windows Troubleshooting
+
+#### Audio still plays after exiting
+This is a known issue when using ASIO4ALL. Working on it! You have to manually end sapf.exe via task
+manager.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Windows support is currently WIP. The following current "quirks" apply:
 
 - It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
     all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
-- History loading from previous sessions isn't working.
 - When pasting in multiline strings, they should work. Just note that many built-in Windows terminals by default will strip out certain characters like tabs,
     ruining your beautiful formatting. This can be changed in the terminal's settings.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 Windows support is currently WIP. The following current limitations apply:
 
-- In order to paste multiline contents, you should make sure the line ending is LF only (not Windows-style CRLF). CRLF pasting isn't working right currently.
 - It will use ASIO and will use the "first" enabled ASIO device, which may not be what you want. Opening the ASIO4ALL panel (in the taskbar tray) and disabling
     all inputs other than your preferred input, then restarting SAPF, should allow it to switch.
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ a version string. You can also confirm with `where gcc` that it's using the bina
 1. Open a cpp file to make sure the extensions activate.
 1. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
 1. You can now build using the Meson build task instead of msys2 shell if you prefer.
-1. You can debug by opening up main.cpp and selecting the "Attach (sapf)" configuration (bottom left), manually
+1. You can debug via selecting the "Attach (sapf)" configuration (bottom left), manually
 running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
 how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
-    - IDK why but it seems like you have to actually have main.cpp open in order for it to succeed in attaching.
+    - If it times out waiting to attach, try restarting VSCode and maybe also
+    closing any msys2 shells if you have any open (not sure what's going on here)?
 
 
 

--- a/README_VSCODE.md
+++ b/README_VSCODE.md
@@ -1,0 +1,138 @@
+# VS Code Development Setup
+
+The trick to making it work is to make sure VSCode is using the ucrt64 binaries for the development toolchain,
+NOT anything installed natively to Windows.
+
+1. Install C/C++ extensions for VSCode.
+2. Install Meson extension for VSCode.
+3. In the settings for Meson, set Meson build path to `C:\msys64\ucrt64\bin\meson` and
+set the Build folder to `build`.
+4. Add your `C:\msys64\ucrt\bin` folder to your Path (via Environment Variables).
+5. Open a windows terminal and make sure that `gcc --version` and `g++ --version` and `gdb --version` return
+a version string. You can also confirm with `where gcc` that it's using the binary within msys2.
+6. Before opening the folder in vscode, create a `.vscode` subdolder and populate it with some files. See the below "Config files" section for some example config files. Tweak the paths to match your own system.
+7. Open a cpp file to make sure the extensions activate.
+8. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
+9. You can now build using the Meson build task instead of msys2 shell if you prefer.
+10. You can debug via selecting the "Attach (sapf)" configuration (bottom left), manually
+running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
+how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
+    - If it times out waiting to attach, try restarting VSCode and maybe also
+    closing any msys2 shells if you have any open (not sure what's going on here)?
+
+
+
+#### Config files
+Below setup uses clang but it should work with other toolchains
+(clang can be installed via msys2's `mingw-w64-ucrt-x86_64-clang` package)
+Example `.vscode/c_cpp_properties.json`
+```json
+{
+    "configurations": [
+        {
+            "name": "ucrt64",
+            "includePath": [
+                "C:/msys64/ucrt64/include/**",
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compilerPath": "C:/msys64/ucrt64/bin/clang++.exe",
+            "windowsSdkVersion": "10.0.22621.0",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-clang-x64",
+            "configurationProvider": "mesonbuild.mesonbuild"
+        }
+    ],
+    "version": 4
+}
+```
+
+Example `.vscode/launch.json`
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceRoot}/build/sapf.exe",
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "(gdb) Launch (chairbender note - not working ATM, use attach instead - everything is garbled)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/sapf.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/build",
+            "environment": [
+                { "name": "MSYSTEM", "value": "UCRT64" },
+                { "name": "MSYS2_PATH_TYPE", "value": "inherit" },
+                { "name": "PATH", "value": "C:\\msys64\\ucrt64\\bin;${env:PATH}" }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}
+```
+
+Example `.vscode/settings.json`
+```json
+{
+    "C_Cpp.default.compileCommands": "c:\\msys64\\home\\kwhip\\sapf\\build/compile_commands.json",
+    "C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild"
+}
+```
+
+Example `.vscode/tasks.json`
+```json
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "meson",
+			"target": "sapf:executable",
+			"mode": "build",
+			"problemMatcher": [
+				"$meson-gcc"
+			],
+			"group": "build",
+			"label": "Meson: Build sapf:executable"
+		}
+	]
+}
+```

--- a/clang.ini
+++ b/clang.ini
@@ -1,0 +1,3 @@
+[binaries]
+c = 'clang.exe'
+cpp = 'clang++.exe'

--- a/clang.ini
+++ b/clang.ini
@@ -1,3 +1,0 @@
-[binaries]
-c = 'clang.exe'
-cpp = 'clang++.exe'

--- a/include/MathFuns.hpp
+++ b/include/MathFuns.hpp
@@ -17,6 +17,7 @@
 #ifndef __MathFuns_h__
 #define __MathFuns_h__
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <stdint.h>
 #include <stdio.h>

--- a/include/VM.hpp
+++ b/include/VM.hpp
@@ -25,10 +25,11 @@
 #include <sys/time.h>
 #include <atomic>
 
-#define USE_LIBEDIT 1
-
 #if USE_LIBEDIT
 #include <histedit.h>
+#else
+#include <readline/history.h>
+#include <readline/readline.h>
 #endif
 
 extern pthread_mutex_t gHelpMutex;
@@ -162,8 +163,8 @@ public:
 	EditLine *el;
 	History *myhistory;
 	HistEvent ev;
-	char historyfilename[PATH_MAX];
 #endif
+	char historyfilename[PATH_MAX];
 	const char *line;
 	int linelen;
 	int linepos;

--- a/include/VM.hpp
+++ b/include/VM.hpp
@@ -26,10 +26,10 @@
 #include <atomic>
 
 #if USE_LIBEDIT
-#include <histedit.h>
+	#include <histedit.h>
 #else
-#include <readline/history.h>
-#include <readline/readline.h>
+	#include <readline/history.h>
+	#include <readline/readline.h>
 #endif
 
 extern pthread_mutex_t gHelpMutex;

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,17 @@ cpp_args = ['-std=c++17']
 link_args = []
 
 # libedit
-deps += dependency('libedit', required: true)
+if host_machine.system() == 'windows'
+    # TODO: Not sure if we need both or if these are valid substitutes
+    deps += dependency('readline', required: true)
+    deps += dependency('history', required: true)
+    cpp_args += ['-DUSE_LIBEDIT=0', '-D_POSIX_THREAD_SAFE_FUNCTIONS']
+    # TODO: needed?
+    #link_args += ['-lrtaudio']
+else
+  deps += dependency('libedit', required: true)
+    cpp_args += ['-DUSE_LIBEDIT=1']
+endif
 
 if get_option('asan')
   cpp_args += ['-fsanitize=address', '-O1', '-fno-omit-frame-pointer', '-g']
@@ -53,7 +63,12 @@ endif
 if get_option('accelerate')
   add_project_arguments('-DSAPF_ACCELERATE', language: 'cpp')
 else
-  deps += dependency('fftw3', required: true, version: '>=3')
+  if host_machine.system() == 'windows'
+    deps += dependency('fftw3', required: true, version: '>=3')
+  else
+    deps += dependency('fftw3', required: true, version: '>=3')
+  endif
+
 endif
 
 if get_option('apple_lock')
@@ -64,6 +79,7 @@ if get_option('audiotoolbox')
   add_project_arguments('-DSAPF_AUDIOTOOLBOX', language: 'cpp')
 else
   deps += dependency('rtaudio', required: true, version: '>=5.2')
+  #TODO: check is not working on windows/mingw
   if not cpp.has_header('RtAudio.h') and cpp.has_header('rtaudio/RtAudio.h')
     add_project_arguments('-DSAPF_RTAUDIO_H=<rtaudio/RtAudio.h>', language: 'cpp')
   endif

--- a/meson.build
+++ b/meson.build
@@ -60,12 +60,7 @@ endif
 if get_option('accelerate')
   add_project_arguments('-DSAPF_ACCELERATE', language: 'cpp')
 else
-  if host_machine.system() == 'windows'
-    deps += dependency('fftw3', required: true, version: '>=3')
-  else
-    deps += dependency('fftw3', required: true, version: '>=3')
-  endif
-
+  deps += dependency('fftw3', required: true, version: '>=3')
 endif
 
 if get_option('apple_lock')

--- a/meson.build
+++ b/meson.build
@@ -44,12 +44,9 @@ link_args = []
 
 # libedit
 if host_machine.system() == 'windows'
-    # TODO: Not sure if we need both or if these are valid substitutes
     deps += dependency('readline', required: true)
     deps += dependency('history', required: true)
     cpp_args += ['-DUSE_LIBEDIT=0', '-D_POSIX_THREAD_SAFE_FUNCTIONS']
-    # TODO: needed?
-    #link_args += ['-lrtaudio']
 else
   deps += dependency('libedit', required: true)
     cpp_args += ['-DUSE_LIBEDIT=1']
@@ -79,7 +76,6 @@ if get_option('audiotoolbox')
   add_project_arguments('-DSAPF_AUDIOTOOLBOX', language: 'cpp')
 else
   deps += dependency('rtaudio', required: true, version: '>=5.2')
-  #TODO: check is not working on windows/mingw
   if not cpp.has_header('RtAudio.h') and cpp.has_header('rtaudio/RtAudio.h')
     add_project_arguments('-DSAPF_RTAUDIO_H=<rtaudio/RtAudio.h>', language: 'cpp')
   endif

--- a/src/CoreOps.cpp
+++ b/src/CoreOps.cpp
@@ -1313,6 +1313,7 @@ static void zplug_(Thread& th, Prim* prim)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#ifndef _WIN32
 #pragma mark GLOB
 
 #include <glob.h>
@@ -1341,6 +1342,33 @@ static void glob_(Thread& th, Prim* prim)
 	
 	th.push(new List(a));
 }
+#else
+#include <windows.h>
+#include <vector>
+#include <iostream>
+
+// TODO: not sure if this works as good a the non-windows one...
+static void glob_(Thread& th, Prim* prim) {
+	P<String> pat = th.popString("glob : pattern");
+
+	std::vector<std::string> results;
+	WIN32_FIND_DATA findFileData;
+	HANDLE hFind = FindFirstFile(pat.get()->cstr(), &findFileData);
+
+	if (hFind != INVALID_HANDLE_VALUE) {
+		do {
+			results.push_back(findFileData.cFileName);
+		} while (FindNextFile(hFind, &findFileData) != 0);
+		FindClose(hFind);
+	}
+
+	P<Array> a = new Array(itemTypeV, results.size());
+	for (int i = 0; i < results.size(); ++i) {
+		a->add(new String(results[i].c_str()));
+	}
+	th.push(new List(a));
+}
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/DelayUGens.cpp
+++ b/src/DelayUGens.cpp
@@ -1549,9 +1549,9 @@ public:
 		int prevSampleDelay = 0;
 		for (int i = 0; i < kNumDelays; ++i) {
 			#ifdef _WIN32
-			double expon = (rand() / 2147483647. - .5) * 0.8;
+				double expon = (rand() / 2147483647. - .5) * 0.8;
 			#else
-			double expon = (random() / 2147483647. - .5) * 0.8;
+				double expon = (random() / 2147483647. - .5) * 0.8;
 			#endif
 			double deviation = pow(interval,  expon);
 			mDelay[i].set(th, *this, delay * deviation, prevSampleDelay);

--- a/src/DelayUGens.cpp
+++ b/src/DelayUGens.cpp
@@ -1560,12 +1560,11 @@ public:
 		for (int i = 0; i < kNumDelays; ++i) {
 			#ifdef _WIN32
 			// this should match the range returned by random() - [0, 2147483647]
-			int random = dist_(gen_);
-			printf("rand %d", random);
+			int random_int = dist_(gen_);
 			#else
-			int random = random();
+			int random_int = random();
 			#endif
-			double expon = (random / 2147483647. - .5) * 0.8;
+			double expon = (random_int / 2147483647. - .5) * 0.8;
 			double deviation = pow(interval,  expon);
 			mDelay[i].set(th, *this, delay * deviation, prevSampleDelay);
 			delay *= interval;

--- a/src/DelayUGens.cpp
+++ b/src/DelayUGens.cpp
@@ -1548,7 +1548,11 @@ public:
 		Z interval = pow(ratio, 1. / (kNumDelays - 1.));
 		int prevSampleDelay = 0;
 		for (int i = 0; i < kNumDelays; ++i) {
+			#ifdef _WIN32
+			double expon = (rand() / 2147483647. - .5) * 0.8;
+			#else
 			double expon = (random() / 2147483647. - .5) * 0.8;
+			#endif
 			double deviation = pow(interval,  expon);
 			mDelay[i].set(th, *this, delay * deviation, prevSampleDelay);
 			delay *= interval;

--- a/src/MathOps.cpp
+++ b/src/MathOps.cpp
@@ -765,12 +765,12 @@ DEFINE_UNOP_BOOL_INT(isspace, isspace((int)a))
 DEFINE_UNOP_BOOL_INT(isupper, isupper((int)a))
 DEFINE_UNOP_BOOL_INT(isxdigit, isxdigit((int)a))
 #ifdef _WIN32
-#pragma push_macro("isascii")
-#undef isascii
-DEFINE_UNOP_BOOL_INT(isascii, __isascii((int)a))
-#pragma pop_macro("isascii")
+	#pragma push_macro("isascii")
+	#undef isascii
+	DEFINE_UNOP_BOOL_INT(isascii, __isascii((int)a))
+	#pragma pop_macro("isascii")
 #else
-DEFINE_UNOP_BOOL_INT(isascii, isascii((int)a))
+	DEFINE_UNOP_BOOL_INT(isascii, isascii((int)a))
 #endif
 
 
@@ -809,12 +809,12 @@ DEFINE_UNOP_INT(tolower, tolower((int)a))
 DEFINE_UNOP_INT(toupper, toupper((int)a))
 // under mingw64, "toascii" is actually a #define for __toascii, so the macro doesn't do what's desired 
 #ifdef _WIN32
-#pragma push_macro("toascii")
-#undef toascii
-DEFINE_UNOP_BOOL_INT(toascii, __toascii((int)a))
-#pragma pop_macro("toascii")
+	#pragma push_macro("toascii")
+	#undef toascii
+	DEFINE_UNOP_BOOL_INT(toascii, __toascii((int)a))
+	#pragma pop_macro("toascii")
 #else
-DEFINE_UNOP_BOOL_INT(toascii, toascii((int)a))
+	DEFINE_UNOP_BOOL_INT(toascii, toascii((int)a))
 #endif
 
 DEFINE_UNOP_FLOATVV2(frac, a - floor(a), vvfloor(out, aa, &n); vDSP_vsubD(out, 1, aa, astride, out, 1, n))
@@ -867,15 +867,15 @@ DEFINE_UNOP_FLOATVV(acosh, acosh(a), vvacosh)
 DEFINE_UNOP_FLOATVV(atanh, atanh(a), vvatanh)
 
 #ifdef _WIN32
-DEFINE_UNOP_FLOAT(J0, _j0(a))
-DEFINE_UNOP_FLOAT(J1, _j1(a))
-DEFINE_UNOP_FLOAT(Y0, _y0(a))
-DEFINE_UNOP_FLOAT(Y1, _y1(a))
+	DEFINE_UNOP_FLOAT(J0, _j0(a))
+	DEFINE_UNOP_FLOAT(J1, _j1(a))
+	DEFINE_UNOP_FLOAT(Y0, _y0(a))
+	DEFINE_UNOP_FLOAT(Y1, _y1(a))
 #else
-DEFINE_UNOP_FLOAT(J0, j0(a))
-DEFINE_UNOP_FLOAT(J1, j1(a))
-DEFINE_UNOP_FLOAT(Y0, y0(a))
-DEFINE_UNOP_FLOAT(Y1, y1(a))
+	DEFINE_UNOP_FLOAT(J0, j0(a))
+	DEFINE_UNOP_FLOAT(J1, j1(a))
+	DEFINE_UNOP_FLOAT(Y0, y0(a))
+	DEFINE_UNOP_FLOAT(Y1, y1(a))
 #endif
 
 DEFINE_UNOP_FLOAT(tgamma, tgamma(a))
@@ -1318,11 +1318,11 @@ DEFINE_BINOP_FLOATVV1(pow, sc_pow(a, b), vvpow(out, bb, aa, &n))
 DEFINE_BINOP_FLOATVV1(atan2, atan2(a, b), vvatan2(out, aa, bb, &n))
 
 #ifdef _WIN32
-DEFINE_BINOP_FLOAT(Jn, _jn((int)b, a))
-DEFINE_BINOP_FLOAT(Yn, _yn((int)b, a))
+	DEFINE_BINOP_FLOAT(Jn, _jn((int)b, a))
+	DEFINE_BINOP_FLOAT(Yn, _yn((int)b, a))
 #else
-DEFINE_BINOP_FLOAT(Jn, jn((int)b, a))
-DEFINE_BINOP_FLOAT(Yn, yn((int)b, a))
+	DEFINE_BINOP_FLOAT(Jn, jn((int)b, a))
+	DEFINE_BINOP_FLOAT(Yn, yn((int)b, a))
 #endif
 
 
@@ -1405,24 +1405,24 @@ void AddMathOps()
 	DEF(isupper, "return whether an ASCII value is upper case.")
 	DEF(isxdigit, "return whether an ASCII value is a hexadecimal digit.")
 	#ifdef _WIN32
-	#pragma push_macro("isascii")
-	#undef isascii
-	DEF(isascii, "return whether a value is ASCII")
-	#pragma pop_macro("isascii")
+		#pragma push_macro("isascii")
+		#undef isascii
+		DEF(isascii, "return whether a value is ASCII")
+		#pragma pop_macro("isascii")
 	#else
-	DEF(isascii, "return whether a value is ASCII")
+		DEF(isascii, "return whether a value is ASCII")
 	#endif
 	
 
 	DEF(tolower, "convert an ASCII character value to lower case.")
 	DEF(toupper, "convert an ASCII character value to upper case.")
 	#ifdef _WIN32
-	#pragma push_macro("toascii")
-	#undef toascii
-	DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
-	#pragma pop_macro("toascii")
+		#pragma push_macro("toascii")
+		#undef toascii
+		DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
+		#pragma pop_macro("toascii")
 	#else
-	DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
+		DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
 	#endif
 
 	DEFN(nonpos, "0<=", "less than or equal to zero.")

--- a/src/MathOps.cpp
+++ b/src/MathOps.cpp
@@ -767,7 +767,6 @@ DEFINE_UNOP_BOOL_INT(isxdigit, isxdigit((int)a))
 #ifdef _WIN32
 #pragma push_macro("isascii")
 #undef isascii
-// TODO: Not sure if this causes linker issue?
 DEFINE_UNOP_BOOL_INT(isascii, __isascii((int)a))
 #pragma pop_macro("isascii")
 #else

--- a/src/MathOps.cpp
+++ b/src/MathOps.cpp
@@ -764,7 +764,16 @@ DEFINE_UNOP_BOOL_INT(ispunct, ispunct((int)a))
 DEFINE_UNOP_BOOL_INT(isspace, isspace((int)a))
 DEFINE_UNOP_BOOL_INT(isupper, isupper((int)a))
 DEFINE_UNOP_BOOL_INT(isxdigit, isxdigit((int)a))
+#ifdef _WIN32
+#pragma push_macro("isascii")
+#undef isascii
+// TODO: Not sure if this causes linker issue?
+DEFINE_UNOP_BOOL_INT(isascii, __isascii((int)a))
+#pragma pop_macro("isascii")
+#else
 DEFINE_UNOP_BOOL_INT(isascii, isascii((int)a))
+#endif
+
 
 DEFINE_UNOP_BOOL_FLOAT(not, a == 0.)
 DEFINE_UNOP_BOOL_FLOAT(nonneg, a >= 0.)
@@ -799,7 +808,15 @@ DEFINE_UNOP_FLOATVV(abs, fabs(a), vvfabs)
 
 DEFINE_UNOP_INT(tolower, tolower((int)a))
 DEFINE_UNOP_INT(toupper, toupper((int)a))
-DEFINE_UNOP_INT(toascii, toascii((int)a))
+// under mingw64, "toascii" is actually a #define for __toascii, so the macro doesn't do what's desired 
+#ifdef _WIN32
+#pragma push_macro("toascii")
+#undef toascii
+DEFINE_UNOP_BOOL_INT(toascii, __toascii((int)a))
+#pragma pop_macro("toascii")
+#else
+DEFINE_UNOP_BOOL_INT(toascii, toascii((int)a))
+#endif
 
 DEFINE_UNOP_FLOATVV2(frac, a - floor(a), vvfloor(out, aa, &n); vDSP_vsubD(out, 1, aa, astride, out, 1, n))
 DEFINE_UNOP_FLOATVV(floor, floor(a), vvfloor)
@@ -850,10 +867,17 @@ DEFINE_UNOP_FLOATVV(asinh, asinh(a), vvasinh)
 DEFINE_UNOP_FLOATVV(acosh, acosh(a), vvacosh)
 DEFINE_UNOP_FLOATVV(atanh, atanh(a), vvatanh)
 
+#ifdef _WIN32
+DEFINE_UNOP_FLOAT(J0, _j0(a))
+DEFINE_UNOP_FLOAT(J1, _j1(a))
+DEFINE_UNOP_FLOAT(Y0, _y0(a))
+DEFINE_UNOP_FLOAT(Y1, _y1(a))
+#else
 DEFINE_UNOP_FLOAT(J0, j0(a))
 DEFINE_UNOP_FLOAT(J1, j1(a))
 DEFINE_UNOP_FLOAT(Y0, y0(a))
 DEFINE_UNOP_FLOAT(Y1, y1(a))
+#endif
 
 DEFINE_UNOP_FLOAT(tgamma, tgamma(a))
 DEFINE_UNOP_FLOAT(lgamma, lgamma(a))
@@ -1294,8 +1318,14 @@ DEFINE_BINOP_INT(imod, sc_imod(a, b))
 DEFINE_BINOP_FLOATVV1(pow, sc_pow(a, b), vvpow(out, bb, aa, &n))
 DEFINE_BINOP_FLOATVV1(atan2, atan2(a, b), vvatan2(out, aa, bb, &n))
 
+#ifdef _WIN32
+DEFINE_BINOP_FLOAT(Jn, _jn((int)b, a))
+DEFINE_BINOP_FLOAT(Yn, _yn((int)b, a))
+#else
 DEFINE_BINOP_FLOAT(Jn, jn((int)b, a))
 DEFINE_BINOP_FLOAT(Yn, yn((int)b, a))
+#endif
+
 
 DEFINE_BINOP_FLOATVV(min, fmin(a, b), vDSP_vminD(const_cast<Z*>(aa), astride, const_cast<Z*>(bb), bstride, out, 1, n))
 DEFINE_BINOP_FLOATVV(max, fmax(a, b), vDSP_vmaxD(const_cast<Z*>(aa), astride, const_cast<Z*>(bb), bstride, out, 1, n))
@@ -1375,11 +1405,26 @@ void AddMathOps()
 	DEF(isspace, "return whether an ASCII value is a graphic character.")
 	DEF(isupper, "return whether an ASCII value is upper case.")
 	DEF(isxdigit, "return whether an ASCII value is a hexadecimal digit.")
+	#ifdef _WIN32
+	#pragma push_macro("isascii")
+	#undef isascii
 	DEF(isascii, "return whether a value is ASCII")
+	#pragma pop_macro("isascii")
+	#else
+	DEF(isascii, "return whether a value is ASCII")
+	#endif
+	
 
 	DEF(tolower, "convert an ASCII character value to lower case.")
 	DEF(toupper, "convert an ASCII character value to upper case.")
+	#ifdef _WIN32
+	#pragma push_macro("toascii")
+	#undef toascii
 	DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
+	#pragma pop_macro("toascii")
+	#else
+	DEF(toascii, "convert a value to ASCII by stripping the upper bits.")
+	#endif
 
 	DEFN(nonpos, "0<=", "less than or equal to zero.")
 	DEFN(nonneg, "0>=", "greater than or equal to zero.")

--- a/src/Play.cpp
+++ b/src/Play.cpp
@@ -172,16 +172,16 @@ public:
 			exit(0);
 		}
 
-		// TODO: it's not using WASAPI / directsound...ASIO only - compiler / linker flags needed?
-		//	the problem with that is on windows, the "default audio device" isn't ASIO. So really, you need
-		//  a way to actually pick the device (could be a command line arg or a prompt that gets saved to a settings file)
-		// if it's asio4all we have to let them pick the channel too.
-		// we could have it prompt then save to a file + allow setting command line args
-		auto deviceIds = this->audio.getDeviceIds();
-		for (auto & element : deviceIds) {
-			auto deviceInfo = this->audio.getDeviceInfo(element);
-			printf("%s id: %d outputs: %d \n", deviceInfo.name.c_str(), element, deviceInfo.outputChannels);
-		}
+		// TODO: below will enumerate devices.
+		// It defaults to ASIO. And it's going to play through the "first channel" which may
+		// not be the user's default audio device.
+		// We could enhance this by getting it to default to a (slower) windows API, and also
+		// giving the ability to somehow pick the driver + device (and maybe "remembering" the settings)
+		// auto deviceIds = this->audio.getDeviceIds();
+		// for (auto & element : deviceIds) {
+		// 	auto deviceInfo = this->audio.getDeviceInfo(element);
+		// 	printf("%s id: %d outputs: %d \n", deviceInfo.name.c_str(), element, deviceInfo.outputChannels);
+		// }
 
 
 		RtAudio::StreamParameters parameters;

--- a/src/Play.cpp
+++ b/src/Play.cpp
@@ -172,6 +172,18 @@ public:
 			exit(0);
 		}
 
+		// TODO: it's not using WASAPI / directsound...ASIO only - compiler / linker flags needed?
+		//	the problem with that is on windows, the "default audio device" isn't ASIO. So really, you need
+		//  a way to actually pick the device (could be a command line arg or a prompt that gets saved to a settings file)
+		// if it's asio4all we have to let them pick the channel too.
+		// we could have it prompt then save to a file + allow setting command line args
+		auto deviceIds = this->audio.getDeviceIds();
+		for (auto & element : deviceIds) {
+			auto deviceInfo = this->audio.getDeviceInfo(element);
+			printf("%s id: %d outputs: %d \n", deviceInfo.name.c_str(), element, deviceInfo.outputChannels);
+		}
+
+
 		RtAudio::StreamParameters parameters;
 		parameters.deviceId = this->audio.getDefaultOutputDevice();
 		parameters.nChannels = this->numChannels;

--- a/src/Play.cpp
+++ b/src/Play.cpp
@@ -162,8 +162,16 @@ int rtPlayerBackendCallback(
 
 class RtPlayerBackend {
 public:
+	// without this, it defaults to ASIO which will be often ASIO4ALL, which won't respect
+	// the OS-level "default output" setting - so defaulting to WASAPI allows us to have a more sensible default
+	// since ultra low latency isn't super important when initially using it
 	RtPlayerBackend(int inNumChannels)
+	#ifdef _WIN32
+		: player(nullptr), numChannels(inNumChannels), audio(RtAudio::WINDOWS_WASAPI)
+	#else
 		: player(nullptr), numChannels(inNumChannels)
+	#endif
+
 	{}
 	
 	int32_t createGraph() {

--- a/src/StreamOps.cpp
+++ b/src/StreamOps.cpp
@@ -5568,7 +5568,6 @@ static void deinterleave(int numChans, int numFrames, float* in, double** out)
 
 static const size_t gSessionTimeMaxLen = 256;
 char gSessionTime[gSessionTimeMaxLen];
-
 #include <time.h>
 
 static void setSessionTime()

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -201,36 +201,78 @@ VM::~VM()
 {
 }
 
-#if USE_LIBEDIT
-static const char* prompt(EditLine *e) 
+static const char* prompt() 
 {
   return "sapf> ";
 }
-static const char* promptParen(EditLine *e) 
+static const char* promptParen() 
 {
   return "(sapf> ";
 }
-static const char* promptSquareBracket(EditLine *e) 
+static const char* promptSquareBracket() 
 {
   return "[sapf> ";
 }
-static const char* promptCurlyBracket(EditLine *e) 
+static const char* promptCurlyBracket() 
 {
   return "{sapf> ";
 }
-static const char* promptLambda(EditLine *e) 
+static const char* promptLambda() 
 {
   return "\\sapf> ";
 }
-static const char* promptString(EditLine *e) 
+static const char* promptString() 
 {
   return "\"sapf> ";
+}
+
+#if !USE_LIBEDIT
+/* A static variable for holding the line. */
+static char *line_read = (char *)NULL;
+
+/* Read a string, and return a pointer to it.
+   Returns NULL on EOF. */
+   // TODO: instead of copying and allocing here, modify the logic on the CONSUMING end to account for no \n on win32
+char *rl_gets()
+{
+	/* If the buffer has already been allocated,
+		return the memory to the free pool. */
+	// if (line_read)
+	// {
+	// 	free(line_read);
+	// 	line_read = (char *)NULL;
+	// }
+
+	/* Get a line from the user. */
+	line_read = readline(rl_prompt);
+
+
+	/* If the line has any text in it,
+		save it on the history. */
+	if (line_read && *line_read)
+		add_history(line_read);
+
+	// Unlike libedit, readline omits the newline, but I think we don't
+	// want that to go in the history - only in the return value...
+	// Allocate space for input + newline + null terminator
+	// TODO: this can't be the best way to do this
+	size_t len = strlen(line_read);
+	char* modified = (char*)malloc(len + 2); // +1 for '\n', +1 for '\0'
+	strcpy(modified, line_read);
+	modified[len] = '\n'; // Append newline
+	modified[len + 1] = '\0'; // Null-terminate
+	free(line_read);
+	line_read = modified;
+	free(modified);
+	return (line_read);
 }
 #endif
 
 void Thread::getLine()
 {	
+	post("getting line\n");
 	if (fromString) return;
+	#if USE_LIBEDIT
 	switch (parsingWhat) {
 		default: case parsingWords : el_set(el, EL_PROMPT, &prompt); break;
 		case parsingString : el_set(el, EL_PROMPT, &promptString); break;
@@ -252,16 +294,43 @@ void Thread::getLine()
 			fclose(logfile);
 		}
 	}
+	#else
+	switch (parsingWhat) {
+		default: case parsingWords : rl_set_prompt(prompt()); break;
+		case parsingString : rl_set_prompt(promptString()); break;
+		case parsingParens : rl_set_prompt(promptParen()); break;
+		case parsingLambda : rl_set_prompt(promptLambda()); break;
+		case parsingArray : rl_set_prompt(promptSquareBracket()); break;
+		case parsingEnvir : rl_set_prompt(promptCurlyBracket()); break;
+	}
+	line = rl_gets();
+	linelen = strlen(line);
+	linepos = 0;
+	if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
+	if (line && linelen) {
+		// TODO: seemingly not working (save / load)
+		write_history(historyfilename);
+		if (logfilename) {
+			FILE* logfile = fopen(logfilename, "a");
+			logTimestamp(logfile);
+			fwrite(line, 1, strlen(line), logfile);
+			fclose(logfile);
+		}
+
+	}
+	#endif
 }
 
 void Thread::logTimestamp(FILE* logfile)
 {
 	timeval tv;
+	time_t t;
+	time(&t);
 	gettimeofday(&tv, NULL);
 	if (previousTimeStamp == 0 || tv.tv_sec - previousTimeStamp > 3600) {
 		previousTimeStamp = tv.tv_sec;
 		char date[32];
-		ctime_r(&tv.tv_sec, date);
+		ctime_r(&t, date);
 		fprintf(logfile, ";;;;;;;; %s", date);
 		fflush(logfile);
 	}
@@ -326,6 +395,24 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 	history(myhistory, &ev, H_LOAD, historyfilename);
 	history(myhistory, &ev, H_SETUNIQUE, 1);
 	el_set(el, EL_HIST, history, myhistory);
+#else
+	// disable the default tab autocomplete
+	rl_bind_key ('\t', rl_insert);
+	// TODO: Could install custom completers
+	rl_set_prompt(prompt());
+	// it should default to "emacs" mode already
+
+	using_history();
+	const char* envHistoryFileName = getenv("SAPF_HISTORY");
+	if (envHistoryFileName) {
+		snprintf(historyfilename, PATH_MAX, "%s", envHistoryFileName);
+	} else {
+		const char* homeDir = getenv("HOME");
+		snprintf(historyfilename, PATH_MAX, "%s/sapf-history.txt", homeDir);
+	}
+	stifle_history(800);
+	read_history(historyfilename);
+	// duplicate entries should be cleared by default (I think this is the same as H_SETUNIQUE?)
 #endif
 	
 	fflush(infile);
@@ -387,6 +474,8 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 	history(myhistory, &ev, H_SAVE, historyfilename);
 	history_end(myhistory);
 	el_end(el);
+#else
+	write_history(historyfilename);
 #endif
 }
 

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -365,6 +365,17 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 	
 	previousTimeStamp = 0;
 
+	const char* envHistoryFileName = getenv("SAPF_HISTORY");
+	if (envHistoryFileName) {
+		snprintf(historyfilename, PATH_MAX, "%s", envHistoryFileName);
+	} else {
+		#ifdef _WIN32
+			const char* homeDir = getenv("USERPROFILE");
+		#else
+			const char* homeDir = getenv("HOME");
+		#endif
+		snprintf(historyfilename, PATH_MAX, "%s/sapf-history.txt", homeDir);
+	}
 #if USE_LIBEDIT
 	el = el_init("sc", stdin, stdout, stderr);
 	el_set(el, EL_PROMPT, &prompt);
@@ -377,13 +388,6 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 		return;
 	}
 
-	const char* envHistoryFileName = getenv("SAPF_HISTORY");
-	if (envHistoryFileName) {
-		snprintf(historyfilename, PATH_MAX, "%s", envHistoryFileName);
-	} else {
-		const char* homeDir = getenv("HOME");
-		snprintf(historyfilename, PATH_MAX, "%s/sapf-history.txt", homeDir);
-	}
 	history(myhistory, &ev, H_SETSIZE, 800);
 	history(myhistory, &ev, H_LOAD, historyfilename);
 	history(myhistory, &ev, H_SETUNIQUE, 1);
@@ -396,13 +400,6 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 	// it should default to "emacs" mode already
 
 	using_history();
-	const char* envHistoryFileName = getenv("SAPF_HISTORY");
-	if (envHistoryFileName) {
-		snprintf(historyfilename, PATH_MAX, "%s", envHistoryFileName);
-	} else {
-		const char* homeDir = getenv("USERPROFILE");
-		snprintf(historyfilename, PATH_MAX, "%s\\sapf-history.txt", homeDir);
-	}
 	stifle_history(800);
 	read_history(historyfilename);
 	// duplicate entries should be cleared by default (I think this is the same as H_SETUNIQUE?)

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -227,100 +227,106 @@ static const char* promptString()
 }
 
 #if !USE_LIBEDIT
-/* A static variable for holding the line. */
-static char *line_read = (char *)NULL;
+	/* A static variable for holding the line. */
+	static char *line_read = (char *)NULL;
 
-/* Read a string, and return a pointer to it.
-   Returns NULL on EOF. */
-   // TODO: instead of copying and allocing here, modify the logic on the CONSUMING end to account for no \n on win32
-char *rl_gets()
-{
-	/* Get a line from the user. */
-	line_read = readline(rl_prompt);
+	/* Read a string, and return a pointer to it.
+	Returns NULL on EOF. */
+	// TODO: instead of copying and allocing here, modify the logic on the CONSUMING end to account for no \n on win32
+	char *rl_gets()
+	{
+		/* Get a line from the user. */
+		line_read = readline(rl_prompt);
 
 
-	/* If the line has any text in it,
-		save it on the history. */
-	if (line_read && *line_read)
-		add_history(line_read);
+		/* If the line has any text in it,
+			save it on the history. */
+		if (line_read && *line_read)
+			add_history(line_read);
 
-	// Unlike libedit, readline omits the newline, but I think we don't
-	// want that to go in the history - only in the return value...
-	// Allocate space for input + newline + null terminator
-	size_t len = strlen(line_read);
-	char* modified = (char*)malloc(len + 2); // +1 for '\n', +1 for '\0'
-	strcpy(modified, line_read);
-	modified[len] = '\n'; // Append newline
-	modified[len + 1] = '\0'; // Null-terminate
-	free(line_read);
-	line_read = modified;
-	free(modified);
-	return (line_read);
-}
+		// Unlike libedit, readline omits the newline, but I think we don't
+		// want that to go in the history - only in the return value...
+		// Allocate space for input + newline + null terminator
+		size_t len = strlen(line_read);
+		char* modified = (char*)malloc(len + 2); // +1 for '\n', +1 for '\0'
+		strcpy(modified, line_read);
+		modified[len] = '\n'; // Append newline
+		modified[len + 1] = '\0'; // Null-terminate
+		free(line_read);
+		line_read = modified;
+		free(modified);
+		return (line_read);
+	}
 #endif
 
 void Thread::getLine()
 {	
 	if (fromString) return;
 	#if USE_LIBEDIT
-	switch (parsingWhat) {
-		default: case parsingWords : el_set(el, EL_PROMPT, &prompt); break;
-		case parsingString : el_set(el, EL_PROMPT, &promptString); break;
-		case parsingParens : el_set(el, EL_PROMPT, &promptParen); break;
-		case parsingLambda : el_set(el, EL_PROMPT, &promptLambda); break;
-		case parsingArray : el_set(el, EL_PROMPT, &promptSquareBracket); break;
-		case parsingEnvir : el_set(el, EL_PROMPT, &promptCurlyBracket); break;
-	}
-	line = el_gets(el, &linelen);
-	linepos = 0;
-	if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
-	if (line && linelen) {
-		history(myhistory, &ev, H_ENTER, line);
-		history(myhistory, &ev, H_SAVE, historyfilename);
-		if (logfilename) {
-			FILE* logfile = fopen(logfilename, "a");
-			logTimestamp(logfile);
-			fwrite(line, 1, strlen(line), logfile);
-			fclose(logfile);
+		switch (parsingWhat) {
+			default: case parsingWords : el_set(el, EL_PROMPT, &prompt); break;
+			case parsingString : el_set(el, EL_PROMPT, &promptString); break;
+			case parsingParens : el_set(el, EL_PROMPT, &promptParen); break;
+			case parsingLambda : el_set(el, EL_PROMPT, &promptLambda); break;
+			case parsingArray : el_set(el, EL_PROMPT, &promptSquareBracket); break;
+			case parsingEnvir : el_set(el, EL_PROMPT, &promptCurlyBracket); break;
 		}
-	}
+		line = el_gets(el, &linelen);
+		linepos = 0;
+		if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
+		if (line && linelen) {
+			history(myhistory, &ev, H_ENTER, line);
+			history(myhistory, &ev, H_SAVE, historyfilename);
+			if (logfilename) {
+				FILE* logfile = fopen(logfilename, "a");
+				logTimestamp(logfile);
+				fwrite(line, 1, strlen(line), logfile);
+				fclose(logfile);
+			}
+		}
 	#else
-	switch (parsingWhat) {
-		default: case parsingWords : rl_set_prompt(prompt()); break;
-		case parsingString : rl_set_prompt(promptString()); break;
-		case parsingParens : rl_set_prompt(promptParen()); break;
-		case parsingLambda : rl_set_prompt(promptLambda()); break;
-		case parsingArray : rl_set_prompt(promptSquareBracket()); break;
-		case parsingEnvir : rl_set_prompt(promptCurlyBracket()); break;
-	}
-	line = rl_gets();
-	linelen = strlen(line);
-	linepos = 0;
-	if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
-	if (line && linelen) {
-		// TODO: seemingly not working (save / load)
-		write_history(historyfilename);
-		if (logfilename) {
-			FILE* logfile = fopen(logfilename, "a");
-			logTimestamp(logfile);
-			fwrite(line, 1, strlen(line), logfile);
-			fclose(logfile);
+		switch (parsingWhat) {
+			default: case parsingWords : rl_set_prompt(prompt()); break;
+			case parsingString : rl_set_prompt(promptString()); break;
+			case parsingParens : rl_set_prompt(promptParen()); break;
+			case parsingLambda : rl_set_prompt(promptLambda()); break;
+			case parsingArray : rl_set_prompt(promptSquareBracket()); break;
+			case parsingEnvir : rl_set_prompt(promptCurlyBracket()); break;
 		}
+		line = rl_gets();
+		linelen = strlen(line);
+		linepos = 0;
+		if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
+		if (line && linelen) {
+			// TODO: seemingly not working (save / load)
+			write_history(historyfilename);
+			if (logfilename) {
+				FILE* logfile = fopen(logfilename, "a");
+				logTimestamp(logfile);
+				fwrite(line, 1, strlen(line), logfile);
+				fclose(logfile);
+			}
 
-	}
+		}
 	#endif
 }
 
 void Thread::logTimestamp(FILE* logfile)
 {
 	timeval tv;
-	time_t t;
-	time(&t);
+	#ifdef _WIN32
+		time_t t;
+		time(&t);
+	#endif
 	gettimeofday(&tv, NULL);
 	if (previousTimeStamp == 0 || tv.tv_sec - previousTimeStamp > 3600) {
 		previousTimeStamp = tv.tv_sec;
 		char date[32];
-		ctime_r(&t, date);
+		#ifdef _WIN32
+			ctime_r(&t, date);
+		#else
+			ctime_r(&tv.tv_sec, date);
+		#endif
 		fprintf(logfile, ";;;;;;;; %s", date);
 		fflush(logfile);
 	}

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -296,7 +296,6 @@ void Thread::getLine()
 		linepos = 0;
 		if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
 		if (line && linelen) {
-			// TODO: seemingly not working (save / load)
 			write_history(historyfilename);
 			if (logfilename) {
 				FILE* logfile = fopen(logfilename, "a");
@@ -401,8 +400,8 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 	if (envHistoryFileName) {
 		snprintf(historyfilename, PATH_MAX, "%s", envHistoryFileName);
 	} else {
-		const char* homeDir = getenv("HOME");
-		snprintf(historyfilename, PATH_MAX, "%s/sapf-history.txt", homeDir);
+		const char* homeDir = getenv("USERPROFILE");
+		snprintf(historyfilename, PATH_MAX, "%s\\sapf-history.txt", homeDir);
 	}
 	stifle_history(800);
 	read_history(historyfilename);

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -235,14 +235,6 @@ static char *line_read = (char *)NULL;
    // TODO: instead of copying and allocing here, modify the logic on the CONSUMING end to account for no \n on win32
 char *rl_gets()
 {
-	/* If the buffer has already been allocated,
-		return the memory to the free pool. */
-	// if (line_read)
-	// {
-	// 	free(line_read);
-	// 	line_read = (char *)NULL;
-	// }
-
 	/* Get a line from the user. */
 	line_read = readline(rl_prompt);
 
@@ -255,7 +247,6 @@ char *rl_gets()
 	// Unlike libedit, readline omits the newline, but I think we don't
 	// want that to go in the history - only in the return value...
 	// Allocate space for input + newline + null terminator
-	// TODO: this can't be the best way to do this
 	size_t len = strlen(line_read);
 	char* modified = (char*)malloc(len + 2); // +1 for '\n', +1 for '\0'
 	strcpy(modified, line_read);
@@ -270,7 +261,6 @@ char *rl_gets()
 
 void Thread::getLine()
 {	
-	post("getting line\n");
 	if (fromString) return;
 	#if USE_LIBEDIT
 	switch (parsingWhat) {
@@ -398,7 +388,7 @@ void Thread::repl(FILE* infile, const char* inLogfilename)
 #else
 	// disable the default tab autocomplete
 	rl_bind_key ('\t', rl_insert);
-	// TODO: Could install custom completers
+	// TODO: Could install custom completers for autocomplete
 	rl_set_prompt(prompt());
 	// it should default to "emacs" mode already
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
 #include <stdio.h>
 // TODO: Is this even needed in this file?
 #if USE_LIBEDIT
-#include <histedit.h>
+	#include <histedit.h>
 #endif
 #include <algorithm>
 #include <sys/stat.h>
@@ -193,13 +193,13 @@ int main (int argc, const char * argv[])
 	vm.log_file = getenv("SAPF_LOG");
 	if (!vm.log_file) {
 		#ifdef _WIN32
-		const char* home_dir = getenv("USERPROFILE");
-		char logfilename[PATH_MAX];
-		snprintf(logfilename, PATH_MAX, "%s\\sapf-log.txt", home_dir);
+			const char* home_dir = getenv("USERPROFILE");
+			char logfilename[PATH_MAX];
+			snprintf(logfilename, PATH_MAX, "%s\\sapf-log.txt", home_dir);
 		#else
-		const char* home_dir = getenv("HOME");
-		char logfilename[PATH_MAX];
-		snprintf(logfilename, PATH_MAX, "%s/sapf-log.txt", home_dir);
+			const char* home_dir = getenv("HOME");
+			char logfilename[PATH_MAX];
+			snprintf(logfilename, PATH_MAX, "%s/sapf-log.txt", home_dir);
 		#endif
 		vm.log_file = strdup(logfilename);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,10 @@
 
 #include "VM.hpp"
 #include <stdio.h>
+// TODO: Is this even needed in this file?
+#if USE_LIBEDIT
 #include <histedit.h>
+#endif
 #include <algorithm>
 #include <sys/stat.h>
 #include "primes.hpp"
@@ -189,9 +192,15 @@ int main (int argc, const char * argv[])
 	
 	vm.log_file = getenv("SAPF_LOG");
 	if (!vm.log_file) {
+		#ifdef _WIN32
+		const char* home_dir = getenv("USERPROFILE");
+		char logfilename[PATH_MAX];
+		snprintf(logfilename, PATH_MAX, "%s\\sapf-log.txt", home_dir);
+		#else
 		const char* home_dir = getenv("HOME");
 		char logfilename[PATH_MAX];
 		snprintf(logfilename, PATH_MAX, "%s/sapf-log.txt", home_dir);
+		#endif
 		vm.log_file = strdup(logfilename);
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,13 +194,11 @@ int main (int argc, const char * argv[])
 	if (!vm.log_file) {
 		#ifdef _WIN32
 			const char* home_dir = getenv("USERPROFILE");
-			char logfilename[PATH_MAX];
-			snprintf(logfilename, PATH_MAX, "%s\\sapf-log.txt", home_dir);
 		#else
 			const char* home_dir = getenv("HOME");
-			char logfilename[PATH_MAX];
-			snprintf(logfilename, PATH_MAX, "%s/sapf-log.txt", home_dir);
 		#endif
+		char logfilename[PATH_MAX];
+		snprintf(logfilename, PATH_MAX, "%s/sapf-log.txt", home_dir);
 		vm.log_file = strdup(logfilename);
 	}
 


### PR DESCRIPTION
Fixes #7 

Adds support for Windows, including CI. Readme has been updated with instructions. It's working fairly decently for me, but I haven't used the program extensively so I'm not sure how much of a gap it has with the other OSes.

Please note, I am fairly new to modern C/C++ development although I have worked with it in the past (my background is mostly in Java)!

Note in the rl_gets method we are allocating and copying the input line so we can append a `\n`, since the entire app was coded with this being expected to be in the input line, but readline removes it. The downside of the approach is this tiny bit of alloc / free and extra string copying, but this is only running when the user enters new lines so it's probably not a big deal. But the big upside is, trying to fix this instead by fixing every place in the code where an assumption is made about \n is going to be complicated and error-prone (at least for me - I even tried it!). So this seems like a tiny price to pay to for that benefit.

It defaults to WASAPI rather than ASIO (the rtaudio default). RtAudio internally should fallback to other audio APIs if for some reason WASAPI doesn't find any devices. IMO this is a better "sensible default" as fussing with ASIO4ALL is a pain for users and I don't think super low latency is that necessary for getting something up and running. WASAPI "just works". We could of course make it more configurable in the future via command line args and a config file (buffer sizes, pick specific audio API etc...).

(Note I previously had various caveats and things not working written here, but as I ended up fixing them fairly quickly, I've incorporated them into this PR since they were all quite small changes, and now it's in a much more "usable" state than it was when I first opened this PR).