### PR TITLE
Doctest + some SIMD BinaryOps via Eigen + compiler target architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,12 @@ jobs:
             mingw-w64-ucrt-x86_64-pkgconf
             mingw-w64-ucrt-x86_64-rtaudio
             mingw-w64-ucrt-x86_64-readline
+            mingw-w64-ucrt-x86_64-ca-certificates
       - name: CI-Build
         run: |
-          echo 'Running in MSYS2!'
-          meson setup build
-          meson compile -C build
+          meson setup --buildtype release build
+          meson test --verbose -C build
+          meson compile sapf_x86_64_v3 -C build
       - name: Save Build Log Artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -57,10 +58,18 @@ jobs:
       run: .github/scripts/install-macos-deps.sh
 
     - name: Setup
-      run: meson setup build
+      run: meson setup --buildtype release build
 
-    - name: Compile
-      run: meson compile -C build
+    - name: Test
+      run: meson test --verbose -C build
+
+    - name: Compile M1
+      if: runner.os == 'macOS'
+      run: meson compile sapf_arm_m1 -C build
+
+    - name: Compile Linux x86
+      if: runner.os != 'macOS'
+      run: meson compile sapf_x86_64_v3 -C build
 
     - name: Save Build Log Artifact
       if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ xcshareddata/
 *.moved-aside
 *.xcuserstate
 .vscode/
+.idea/
+subprojects/*/

--- a/README.md
+++ b/README.md
@@ -10,11 +10,24 @@ a Nix flake is included. simply run:
 
 ```shell
 nix develop
-meson setup build
+meson setup --buildtype release build
 meson compile -C build
 ```
 
-and you should get a binary at `./build/sapf`.
+and you should get a binary at `./build/sapf`. This will be optimized for your
+native architecture and has the maximum level of optimization. This is recommended for
+normal usage. 
+
+To build an
+unoptimized binary, simply omit the `--buildtype release` param (which will default to
+`--buildtype debug`). If you've already ran `setup` and want to change the buildtype to `debug`, you can run
+```shell
+meson configure --buildtype debug build
+meson compile -C build
+```
+Note you can view the current buildtype setting via `meson configure build`.
+
+You can specify different targets defined in the meson.build file such as `meson compile sapf_x86_64_v3 -C build`.
 
 if not using Nix, you will need to install dependencies manually instead of the `nix develop`. the mandatory dependencies for a portable build are currently:
 
@@ -27,6 +40,28 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 - [install-debian-deps.sh](.github/scripts/install-debian-deps.sh) (Debian, Ubuntu, Mint, etc.)
 - [install-macos-deps.sh](.github/scripts/install-macos-deps.sh) (macOS with Homebrew)
+
+## running tests
+Tests are written using doctest (which is obtained via a wrap) and located in the `tests` folder.
+See [the doctest documentation](https://github.com/doctest/doctest/tree/master?tab=readme-ov-file#documentation) for more details.
+
+You can use meson test to run the tests.
+
+This will respect the `--buildtype` setting. For optimal debugging experience,
+you should use the `debug` buildtype. You can check the current buildtype with
+`meson configure build`. To change it, you can run `meson configure --buildtype debug build`.
+
+The below will run the tests
+```shell
+meson test --verbose -C build
+```
+Without `--verbose` you won't get the doctest test report (not to be confused with meson's
+own, less useful test report) printed to stdout and instead would have to view the test
+log file.
+
+Note there is currently a feature request for doctest for better integration 
+with meson but it is not yet implemented ATTOW: https://github.com/doctest/doctest/issues/531
+This seems to be why the default meson test report isn't that useful.
 
 ## Windows Usage Caveats
 
@@ -48,24 +83,28 @@ if the package exists for your architecture.
 "root directory" is for your msys2 / mingw64 shells. For this guide we will assume the default of `C:\msys64`
 2. If you haven't yet, clone or copy this repo somewhere inside the msys2 install. For example within the msys2 shell you could install git via
 `pacman -S git` and then git clone this repo into your "home" folder.
-3. Open a msys2 (ucrt) shell and install some needed development dependencies
+3. Open a msys2 (ucrt) shell and install some needed development dependencies.
+    (Note the ca-certificates are required in order to download the gtest wrap, and in general you'll
+    have a bad time doing anything on msys2 without these certs.)
    ```shell
    # press ENTER when prompted to choose "all"
-   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+   pacman -S --needed base-devel \
+    mingw-w64-ucrt-x86_64-toolchain
    pacman -S \
     mingw-w64-ucrt-x86_64-meson \
     mingw-w64-ucrt-x86_64-fftw \
     mingw-w64-ucrt-x86_64-libsndfile \
     mingw-w64-ucrt-x86_64-pkgconf \
     mingw-w64-ucrt-x86_64-rtaudio \
-    mingw-w64-ucrt-x86_64-readline
+    mingw-w64-ucrt-x86_64-readline \
+    mingw-w64-ucrt-x86_64-ca-certificates
    ```
 4. Close and reopen the shell to ensure it loads everything you just installed. 
 5. Now we can try to build in the msys2 (ucrt) shell.
 Navigate to the root directory of this repo.
 6.  ```shell
-    # remove --buildtype debug to build without debug symbols
-    meson setup --buildtype debug build 
+    # remove --buildtype release to build an unoptimized exe with debug symbols
+    meson setup --buildtype release build 
     meson compile -C build
     ```
 7. You should see `sapf.exe` is created under the `${workspaceFolder}/build` directory.
@@ -80,6 +119,3 @@ When setting up your IDE, make sure it's using the ucrt64 libraries (C:\msys64\u
 and binaries (C:\msys64\ucrt64\bin) for compilation / linking and NOT your native windows libraries / binaries.
 
 See README_VSCODE.md for vscode-specific setup.
-Since it's not exactly straightforward to get everything working nicely in VSCode under Windows, here's 
-some guidance.
-

--- a/README_VSCODE.md
+++ b/README_VSCODE.md
@@ -13,7 +13,8 @@ a version string. You can also confirm with `where gcc` that it's using the bina
 6. Before opening the folder in vscode, create a `.vscode` subdolder and populate it with some files. See the below "Config files" section for some example config files. Tweak the paths to match your own system.
 7. Open a cpp file to make sure the extensions activate.
 8. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
-9. You can now build using the Meson build task instead of msys2 shell if you prefer.
+9. You can now build using the Meson build task instead of msys2 shell if you prefer. For best
+debugging experience you probably want to build the `sapf_unoptimized_testable` target which disables optimizations.
 10. You can debug via selecting the "Attach (sapf)" configuration (bottom left), manually
 running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
 how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
@@ -105,6 +106,36 @@ Example `.vscode/launch.json`
                     "ignoreFailures": true
                 }
             ]
+        },
+        {
+            "name": "(gdb) Debug Test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/test_unoptimized.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/build",
+            "environment": [
+                { "name": "MSYSTEM", "value": "UCRT64" },
+                { "name": "MSYS2_PATH_TYPE", "value": "inherit" },
+                { "name": "PATH", "value": "C:\\msys64\\ucrt64\\bin;${env:PATH}" }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "Meson: Build test_unoptimized:executable"
         }
     ]
 }

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ sources = [
   'src/elapsedTime.cpp',
   'src/ErrorCodes.cpp',
   'src/FilterUGens.cpp',
-  'src/main.cpp',
   'src/MathFuns.cpp',
   'src/MathOps.cpp',
   'src/Midi.cpp',
@@ -61,6 +60,7 @@ if get_option('accelerate')
   add_project_arguments('-DSAPF_ACCELERATE', language: 'cpp')
 else
   deps += dependency('fftw3', required: true, version: '>=3')
+  deps += dependency('eigen3', required: true)
 endif
 
 if get_option('apple_lock')
@@ -112,11 +112,95 @@ if get_option('manta')
   add_project_arguments('-DSAPF_MANTA', language: 'cpp')
 endif
 
+# main should only be in release build because otherwise it conflicts with the main
+# method added by doctest in test builds
+release_sources = sources + 'src/main.cpp'
+
+# build targeting the native system this was built on. If buildtype is debug,
+# no target architecture will be specified, to ensure the best debugging experience.
 executable(
   'sapf',
-  sources,
+  release_sources,
   include_directories: [include_directories('include')],
   dependencies: deps,
-  cpp_args : cpp_args,
+  cpp_args : cpp_args + (get_option('buildtype').startswith('debug') ? [] : ['-march=native']),
   link_args : link_args
 )
+
+# The below builds target specific architectures. Because this program uses
+# SIMD, the best performance is achieved when a user uses the most recent architecture supported
+# by their CPU. However, users will get the best results (even better performance) if they build the
+# library themselves (target `sapf` above with `--buildtype release`)
+
+# should have maximum compatibility with ancient x86_64 cpus
+executable(
+  'sapf_x86_64',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march==x86-64'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# for somewhat older x86 CPUs (2008ish)
+executable(
+  'sapf_x86_64_v2',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=x86-64-v2'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# for more cutting edge x86 cpus
+executable(
+  'sapf_x86_64_v3',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=x86-64-v3'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# support M1 chip and newer
+executable(
+  'sapf_arm_m1',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=armv8.4-a', '-mcpu=apple-m1'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# support M3 chip
+executable(
+  'sapf_arm_m3',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=armv8.5-a', '-mcpu=apple-m3'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# tests
+test_deps = deps + dependency('doctest', required: true)
+test_sources = sources + 'test/test_MathOps.cpp'
+
+# Just like the main executable, this respects the buildtype param. The target architecture is
+# omitted if it's a debug build, ensuring the best debugging experience
+test_sapf = executable(
+  'test_sapf',
+  test_sources,
+  include_directories: [include_directories('include')],
+  dependencies: test_deps,
+  cpp_args :  cpp_args + (get_option('buildtype').startswith('debug') ? [] : ['-march=native']),
+  link_args : link_args,
+  build_by_default: false
+)
+
+test('all', test_sapf)

--- a/subprojects/doctest.wrap
+++ b/subprojects/doctest.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = doctest-2.4.11
+source_url = https://github.com/doctest/doctest/archive/refs/tags/v2.4.11.tar.gz
+source_filename = doctest-2.4.11.tar.gz
+source_hash = 632ed2c05a7f53fa961381497bf8069093f0d6628c5f26286161fbd32a560186
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/doctest_2.4.11-1/doctest-2.4.11.tar.gz
+wrapdb_version = 2.4.11-1
+
+[provide]
+dependency_names = doctest

--- a/subprojects/eigen.wrap
+++ b/subprojects/eigen.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = eigen-3.4.0
+source_url = https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
+source_filename = eigen-3.4.0.tar.bz2
+source_hash = b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
+patch_filename = eigen_3.4.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/eigen_3.4.0-2/get_patch
+patch_hash = cb764fd9fec02d94aaa2ec673d473793c0d05da4f4154c142f76ef923ea68178
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/eigen_3.4.0-2/eigen-3.4.0.tar.bz2
+wrapdb_version = 3.4.0-2
+
+[provide]
+eigen3 = eigen_dep

--- a/test/test_MathOps.cpp
+++ b/test/test_MathOps.cpp
@@ -1,0 +1,49 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "Object.hpp"
+#include "doctest.h"
+#include <array>
+
+
+#define CHECK_ARR(expected, actual, n) \
+	do { \
+		LOOP(i,n) { CHECK(out[i] == doctest::Approx(expected[i]).epsilon(1e-9)); } \
+	} while (0)
+
+
+// so we can access ops directly
+extern BinaryOp* gBinaryOpPtr_plus;
+extern BinaryOp* gBinaryOpPtr_minus;
+extern BinaryOp* gBinaryOpPtr_mul;
+extern BinaryOp* gBinaryOpPtr_div;
+
+using std::array;
+
+void check_binop_loopz(BinaryOp& op, const std::array<Z, 3> a, int astride, const std::array<Z, 3> b, int bstride) {
+	double out[3];
+	double expected[3] = {op.op(a[0], b[0]), op.op(a[1], b[1]), op.op(a[2], b[2])};
+	op.loopz(3, a.data(), 1, b.data(), 1, out);
+	CHECK_ARR(expected, out, 3);
+}
+
+void check_binop_loopz(BinaryOp& op, int astride, int bstride) {
+	check_binop_loopz(op, {1, 2, 3}, astride, {4, 5, 6}, bstride);
+}
+
+#define CHECK_IDENTITY_BINOP(op) \
+	do { \
+		SUBCASE(#op) { \
+			SUBCASE("stride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 1, 1); } \
+			SUBCASE("stride 0") { check_binop_loopz(*gBinaryOpPtr_##op, 0, 0); } \
+			SUBCASE("astride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 1, 0); } \
+			SUBCASE("bstride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 0, 1); } \
+			SUBCASE("a 0") { check_binop_loopz(*gBinaryOpPtr_##op, {0}, 0, {4, 5, 6}, 1); } \
+			SUBCASE("b 0") { check_binop_loopz(*gBinaryOpPtr_##op, {1, 2, 3}, 1, {4, 5, 6}, 0); } \
+		} \
+	} while (0)
+
+TEST_CASE("identity binops") {
+	CHECK_IDENTITY_BINOP(plus);
+	CHECK_IDENTITY_BINOP(minus);
+	CHECK_IDENTITY_BINOP(div);
+	CHECK_IDENTITY_BINOP(mul);
+}


### PR DESCRIPTION
This is a more fully-fledged PR than #15 that I would intend to get merged unless there are large changes needed. Relates to #8 .

This PR:

1. Adds doctest and the related setup to have them run in CI builds. The tests are inline with the production code. If we don't like this, we can move them to a more "traditional" setup, though I think considering how this project is structured, there are some benefits to doing it this way.
2. Adds some doctests to test all of the BinaryOp_ structs (NOT the BINOP / UNOP stuff yet! But from my brief check, Eigen should be able to support those various functions).
3. Adds eigen + ports the BinaryOp code to use it, which should theoretically use SIMD instructions.
4. Setup the build to enable optimizations so the vectorization capabilities are actually used.
5. Some updates to the README to fix formatting quirks + describe the new changes to the build system.

The CI has changed slightly:
1. Tests are now run, and the build will fail if tests fail.
2. Each of the 3 systems builds for a specific target architecture, which is needed in order for the SIMD stuff to actually be used while still building a binary that should run on many systems. Since we don't distribute the binaries currently, it doesn't really matter, but I used this to illustrate how we could possibly handle this in the future. 
    - On the Windows / Linux builder we target x86_64_v2 which should be compatible with 2008-ish or newer CPUs apparently (don't quote me on that number). On OSX it targets M1 or newer. 
    - We can of course target multiple architectures if needed in the future.

This affects the following development processes:
1. When building, you should specify a target and not simply build all targets (`meson compile sapf -C build` gets you the "native" optimizations for your system). You won't be able to build all the targets.
2. When testing, you can run tests either against the optimized or unoptimized exe i.e. `meson test unoptimized ...`. The idea being, you can build and test more quickly only by testing the unoptimized exe. Not sure if it's significant enough to be worth it.

This is literally the first time I've ever had to think about compiling for specific architectures and optimization levels so there might be mistakes. I had to research a fair bit and do some trial and error to put this together. It's also the first time I've done anything with SIMD...

I wanted to submit this before porting ALL of the Accelerate code over so you can see how I'm approaching it and I can course-correct before I go too far down the wrong path. Plus there's a lot of Accelerate stuff so it should probably be split into multiple smaller PRs anyway.

# Doctest Details
One (pretty minor) downside I am noticing with doctest is this: https://github.com/doctest/doctest/discussions/740

Basically, if we have test support stuff (like my `CHECK_ARR`), we either have to leave it in the release build, or we have to always wrap our doctests themselves PLUS the test support stuff in #ifndef DOCTEST_CONFIG_DISABLE. Because the way doctest generates the tests is such that they are reduced to "no-op" templates, but still must be able to parse. I've opted for the latter approach to minimize test code leaking into production code.

# Eigen / SIMD Details
I considered Eigen, SIMDe, XSIMD, and JUCE dsp library as options. Eigen seemed to be the closest to the level of abstraction that we needed (similar to Accelerate) while also having everything we need. XSIMD was the close alternative but it is more "DIY" (we were going to have to deal with alignment and simd size ourselves).

By using the `Map` type from Eigen, it reads / writes directly from / to the source array rather than having to copy / allocate into an Eigen-specific object. I'm not sure how it deals with alignment internally, but at least on the systems I've run it so far, I'm not seeing alignment assertion errors. If it does become a problem, I think we can specifically use an allocator provided by Eigen.

Once you have the `Map` instance, you can perform normal operations on it (by using an Array type, they are pairwise rather than matrix / vector algebra).

